### PR TITLE
PropertyContentLiteral.Href Should Return Null

### DIFF
--- a/BaseSpace.SDK/Types/PropertyContentLiteral.cs
+++ b/BaseSpace.SDK/Types/PropertyContentLiteral.cs
@@ -16,7 +16,7 @@ namespace Illumina.BaseSpace.SDK.Types
 
         public Uri Href
         {
-            get { return new Uri(""); }
+            get { return null; }
         }
 
         public string Content { get; set; }


### PR DESCRIPTION
The getter for `PropertyContentLiteral.Href` attempts to create an instance of `Uri` by passing an empty string to the `Uri` constructor. This causes a `UriFormatException` to be thrown. The `Href` getter should simply return `null`.
