### PR TITLE
Add overload of DownloadFile to client interface.

### DIFF
--- a/BaseSpace.SDK/Interfaces/IBaseSpaceClient.cs
+++ b/BaseSpace.SDK/Interfaces/IBaseSpaceClient.cs
@@ -82,6 +82,8 @@ namespace Illumina.BaseSpace.SDK
 
         void DownloadFile(FileCompact file, string filePath, CancellationToken token = new CancellationToken());
 
+        void DownloadFile(FileCompact file, string filePath, int maxThreadCount, CancellationToken token = new CancellationToken());
+
         void DownloadFile(FileCompact file, string filePath, int maxChunkSize, int maxThreadCount, CancellationToken token = new CancellationToken());
         
         event FileDownloadProgressChangedEventHandler FileDownloadProgressChanged;


### PR DESCRIPTION
`BaseSpaceClient` already contains the implementation. This change exposes the method through the `IBaseSpaceClient` interface.
