### PR TITLE
File Upload Issue

### DIFF
--- a/BaseSpace.SDK/Infrastructure/FileUpload.cs
+++ b/BaseSpace.SDK/Infrastructure/FileUpload.cs
@@ -18,7 +18,7 @@ namespace Illumina.BaseSpace.SDK
         protected IClientSettings ClientSettings { get; set; }
         protected IRequestOptions Options { get; set; }
         protected ILog Logger = LogManager.GetCurrentClassLogger();
-        
+
         public FileUpload(IWebClient webClient, IClientSettings settings, IRequestOptions options)
         {
             WebClient = webClient;
@@ -26,20 +26,20 @@ namespace Illumina.BaseSpace.SDK
             Options = options;
         }
 
-		public virtual TResult UploadFile<TResult>(FileUploadRequestBase<TResult> request)
-			where TResult : FileResponse
-		{
-			Logger.DebugFormat("numthreads {0}", request.ThreadCount);
-			TResult file = null;
+        public virtual TResult UploadFile<TResult>(FileUploadRequestBase<TResult> request)
+            where TResult : FileResponse
+        {
+            Logger.DebugFormat("numthreads {0}", request.ThreadCount);
+            TResult file = null;
 
             RetryLogic.DoWithRetry(ClientSettings.RetryAttempts, string.Format("Uploading file {0}", request.FileInfo.Name),
                                    () =>
-	                               {
+                                   {
                                        request.MultiPart = request.FileInfo.Length >= ClientSettings.FileUploadMultipartSizeThreshold;
 
                                        file = request.MultiPart.Value ?
                                            UploadFile_MultiPart(request) :
-										   WebClient.Send(request);
+                                           WebClient.Send(request);
                                    }, Logger, retryHandler:
                                    (exc) =>
                                    {
@@ -59,14 +59,14 @@ namespace Illumina.BaseSpace.SDK
             return file;
         }
 
-		protected virtual TResult UploadFile_MultiPart<TResult>(FileUploadRequestBase<TResult> request)
-			where TResult : FileResponse
+        protected virtual TResult UploadFile_MultiPart<TResult>(FileUploadRequestBase<TResult> request)
+            where TResult : FileResponse
         {
             Logger.InfoFormat("File Upload: {0}: Initiating multipart upload", request.FileInfo.Name);
 
-			var fileUploadresp = WebClient.Send(request);
+            var fileUploadresp = WebClient.Send(request);
 
-			var server = ClientSettings.BaseSpaceApiUrl.TrimEnd('/');
+            var server = ClientSettings.BaseSpaceApiUrl.TrimEnd('/');
 
             uint chunkSize = ClientSettings.FileUploadMultipartChunkSize;
 
@@ -125,7 +125,7 @@ namespace Illumina.BaseSpace.SDK
                          }));
 
             bool success = errorSignal.WaitOne(0) == false;
-           
+
             var status = success ? FileUploadStatus.complete : FileUploadStatus.aborted;
 
             var statusReq = new FileRequestPost<TResult>
@@ -143,7 +143,7 @@ namespace Illumina.BaseSpace.SDK
 
 
         static object _syncRead = new object();
-        
+
         protected virtual void UploadPart(string fullUrl, FileInfo fileToUpload, long startPosition, int partNumber, ManualResetEvent errorSignal, string partDescription, uint chunkSize)
         {
             RetryLogic.DoWithRetry(ClientSettings.RetryAttempts, string.Format("Uploading part {0} of {1}", partDescription, fileToUpload.Name),
@@ -159,9 +159,9 @@ namespace Illumina.BaseSpace.SDK
                         {
                             data = BufferPool.GetChunk((int)chunkSize);
 
-	                        var authentication = ClientSettings.Authentication;
-	                        authentication.UpdateHttpHeader(wc.Headers, new Uri(fullUrl), "PUT");
-                            
+                            var authentication = ClientSettings.Authentication;
+                            authentication.UpdateHttpHeader(wc.Headers, new Uri(fullUrl), "PUT");
+
                             int actualSize;
                             int desiredSize = (int)Math.Min(fileToUpload.Length - startPosition, chunkSize);
                             lock (_syncRead) // avoid thrashing the disk
@@ -196,18 +196,33 @@ namespace Illumina.BaseSpace.SDK
         }
 
         private class BSWebClient : WebClient
-		{
-			//TODO: Doesnt seem right? Need refactor?
-			// const int CONNECTION_LIMIT = 16;
-			protected override WebRequest GetWebRequest(Uri address)
-			{
-				var request = base.GetWebRequest(address) as HttpWebRequest;
+        {
+            //TODO: Doesnt seem right? Need refactoring?
+            // const int CONNECTION_LIMIT = 16;
+            protected override WebRequest GetWebRequest(Uri address)
+            {
+                var request = base.GetWebRequest(address) as HttpWebRequest;
 
-				if (request != null && request.ServicePoint.ConnectionLimit < 20)
-					request.ServicePoint.ConnectionLimit = 10000;  //Note: Is this changing global value?
+                if (request != null && request.ServicePoint.ConnectionLimit < 20)
+                    request.ServicePoint.ConnectionLimit = 10000;  //Note: Is this changing global value?
 
-				return request;
-			}
-		}
+                // Workaround to support slow internet connections.
+                // On very slow internet connections (specifically between the client and the BaseSpace API server), 
+                // multi-part file uploads tend to fail due to a request timeout.
+                if (request != null)
+                {
+                    // Set the timeout to 10 min (vs default 100 sec). 
+                    // This setting was confirmed to work for the minimum upload part size of 5 MB
+                    // on connections with sustainable upload speeds of 20 KB/s and higher.
+                    // Technically, this timeout should be tied to the configured part size, 
+                    // but cursory tests demonstrated that for larger part sizes greater timeouts
+                    // start inducing errors (500 in particular) on the server side.
+                    request.Timeout = 600000;
+                    request.ReadWriteTimeout = request.Timeout;
+                }
+
+                return request;
+            }
+        }
     }
 }


### PR DESCRIPTION
For this take a look at the BSWebClient class only.  I don't intend for you to actually merge this - just to create a discussion.

We ran into a problem of file upload timeouts when we ran an application that uploads files.  Turns out that the minimum chunk size is 5mb, and that for an individual piece we got a timeout/retry happening.  

We just hardcoded a bigger timeout - not the way to fix this.  Maybe have a small upload job and measure the performance - then set the timeout value accordingly.  This problem can be reproduced using some IP traffic shaping tool and limiting your upload speed to something slow - e.g. 100kbps.