### PR TITLE
To include permissions in api users/current/projects

### DIFF
--- a/BaseSpace.SDK.Tests/Integration/ProjectsTests.cs
+++ b/BaseSpace.SDK.Tests/Integration/ProjectsTests.cs
@@ -30,6 +30,24 @@ namespace Illumina.BaseSpace.SDK.Tests.Integration
         }
 
         [Fact]
+        public void CanGetUserProjectsFirstPageWithPermissions()
+        {
+            // Include=permissions
+            ListProjectsResponse response = Client.ListProjects(new ListProjectsRequest { Include = new[]{"permissions" }});
+
+            Assert.NotNull(response);
+            Assert.True(response.Response.TotalCount > 0); //make sure account has at least 1 for access token
+            ProjectCompact projectResult = response.Response.Items[0];
+
+            Assert.NotNull(projectResult);
+            Assert.NotEmpty(projectResult.Id);
+            Assert.NotEmpty(projectResult.Name);
+            Assert.NotSame(projectResult.Id, projectResult.Name);
+            Assert.NotNull(projectResult.Permissions);
+            Assert.True(projectResult.DateCreated > new DateTime(2009, 1, 1));           
+        }
+
+        [Fact]
         public void CanPageThroughProjects()
         {
 

--- a/BaseSpace.SDK.Tests/Integration/ProjectsTests.cs
+++ b/BaseSpace.SDK.Tests/Integration/ProjectsTests.cs
@@ -16,35 +16,13 @@ namespace Illumina.BaseSpace.SDK.Tests.Integration
         [Fact]
         public void CanGetUserProjectsFirstPage()
         {
-           ListProjectsResponse response = Client.ListProjects(new ListProjectsRequest());
-            
-           Assert.NotNull(response);
-           Assert.True(response.Response.TotalCount > 0); //make sure account has at least 1 for access token
-            ProjectCompact projectResult = response.Response.Items[0];
-
-           Assert.NotNull(projectResult);
-            Assert.NotEmpty(projectResult.Id);
-            Assert.NotEmpty(projectResult.Name);
-            Assert.NotSame(projectResult.Id, projectResult.Name);
-            Assert.True(projectResult.DateCreated > new DateTime(2009,1,1));
+            TestHelpers.CanGetUserProjectsFirstPage(Client);          
         }
 
         [Fact]
         public void CanGetUserProjectsFirstPageWithPermissions()
         {
-            // Include=permissions
-            ListProjectsResponse response = Client.ListProjects(new ListProjectsRequest { Include = new[]{"permissions" }});
-
-            Assert.NotNull(response);
-            Assert.True(response.Response.TotalCount > 0); //make sure account has at least 1 for access token
-            ProjectCompact projectResult = response.Response.Items[0];
-
-            Assert.NotNull(projectResult);
-            Assert.NotEmpty(projectResult.Id);
-            Assert.NotEmpty(projectResult.Name);
-            Assert.NotSame(projectResult.Id, projectResult.Name);
-            Assert.NotNull(projectResult.Permissions);
-            Assert.True(projectResult.DateCreated > new DateTime(2009, 1, 1));           
+            TestHelpers.CanGetUserProjectsFirstPage(Client, new[] { ProjectIncludes.PERMISSIONS });                        
         }
 
         [Fact]
@@ -115,21 +93,13 @@ namespace Illumina.BaseSpace.SDK.Tests.Integration
         [Fact]
         public void CanGetProject()
         {
-            var project = TestHelpers.CreateRandomTestProject(Client);
+            TestHelpers.CanGetProject(Client);            
+        }
 
-            ListProjectsResponse listProjectResponse = Client.ListProjects(new ListProjectsRequest() { Limit = 1, Offset = 0, Name = project.Name });
-            Assert.True(listProjectResponse.Response.Items.Length == 1);
-            var compactProject = listProjectResponse.Response.Items[0];
-            Assert.True(project.Id == compactProject.Id);
-            Assert.True(project.Name == compactProject.Name);
-
-            var getProjectResponse = Client.GetProject(new GetProjectRequest(compactProject.Id));
-            var retrievedProject = getProjectResponse.Response;
-            Assert.True(project.Id == retrievedProject.Id);
-            Assert.True(project.Name == retrievedProject.Name);
-            Assert.True(project.HrefAppResults == retrievedProject.HrefAppResults);
-            Assert.True(project.HrefBaseSpaceUI == retrievedProject.HrefBaseSpaceUI);
-            Assert.True(project.HrefSamples == retrievedProject.HrefSamples);
+        [Fact]
+        public void CanGetProjectWithPermissions()
+        {
+            TestHelpers.CanGetProject(Client,  new []{ProjectIncludes.PERMISSIONS});            
         }
 
         [Fact]

--- a/BaseSpace.SDK/Constants.cs
+++ b/BaseSpace.SDK/Constants.cs
@@ -25,4 +25,12 @@
         public const string FILES_SAMPLE = "sample_files";
         public const string FILES_BOTH_SAMPLE_AND_APPRESULT = "sample_files,appresult_files";
     }
+
+    /// <summary>
+    /// Include the const strings to pass to the query
+    /// </summary>
+    public static class ProjectIncludes
+    {
+        public const string PERMISSIONS = "Permissions";
+    }
 }

--- a/BaseSpace.SDK/ServiceModels/Request/GetProjectRequest.cs
+++ b/BaseSpace.SDK/ServiceModels/Request/GetProjectRequest.cs
@@ -11,6 +11,11 @@
         {
         }
 
+        /// <summary>
+        /// Passing to the query the Include which can be set using constants in class ProjectIncludes
+        /// </summary>
+        public string[] Include { get; set; }  
+
 		protected override string GetUrl()
 		{
 			return string.Format("{0}/projects/{1}", Version, Id);

--- a/BaseSpace.SDK/ServiceModels/Request/ListProjectsRequest.cs
+++ b/BaseSpace.SDK/ServiceModels/Request/ListProjectsRequest.cs
@@ -7,6 +7,8 @@ namespace Illumina.BaseSpace.SDK.ServiceModels
     {
         public string Name { get; set; }
 
+        public string[] Include { get; set; }        
+
 		protected override string GetUrl()
 		{
 			return String.Format("{0}/users/current/projects", Version);

--- a/BaseSpace.SDK/ServiceModels/Request/ListProjectsRequest.cs
+++ b/BaseSpace.SDK/ServiceModels/Request/ListProjectsRequest.cs
@@ -7,11 +7,14 @@ namespace Illumina.BaseSpace.SDK.ServiceModels
     {
         public string Name { get; set; }
 
+        /// <summary>
+        /// Passing to the query the Include which can be set using constants in class ProjectIncludes
+        /// </summary>
         public string[] Include { get; set; }        
 
 		protected override string GetUrl()
 		{
 			return String.Format("{0}/users/current/projects", Version);
 		}
-	}
+	}    
 }

--- a/BaseSpace.SDK/Types/Project.cs
+++ b/BaseSpace.SDK/Types/Project.cs
@@ -29,7 +29,22 @@ namespace Illumina.BaseSpace.SDK.Types
         {
             return string.Format("Href: {0}; Name: {1}", Href, Name);
         }
+
+        [DataMember]
+        public Permissions Permissions { get; set; }
     }
+
+    [DataContract(Name = "Permissions")]
+    public class Permissions
+    {
+        [DataMember]
+        public string[] UserOperations { get; set; }
+
+        [DataMember]
+        public string[] AccessTokenOperations { get; set; }
+
+      
+    }   
 
     [DataContract()]
     public class Project : ProjectCompact, IPropertyContainingResource


### PR DESCRIPTION
Describe level of access to projects by users and tokens via the APIs:

* GET: users/id/projects API
* GET: projects/{id}

```javascript
{
    "Permissions" :
    {
        "UserOperations": [ "READ", "WRITE", "OWN" ],
        "AccessTokenOperations": [ "READ" ] 
    }
 }
```
This is included in the response body when the API is invoked with
?include=permissions

If a token is used to authenticate, then both the UserOperations and AccessTokenOperations fields are shown and populated. If the user is using browser authentication for this API call, then the response will not contain the AccessTokenOperations and will only contain the UserOperations.
